### PR TITLE
Resolved 'Too many commands' bug around incoming texts.

### DIFF
--- a/backend_src/index.js
+++ b/backend_src/index.js
@@ -237,7 +237,7 @@ app.use(middleware.handle(i18next));
 */
 app.post('/sms/in/:lng', async (req, res) => {
   // Parse incoming text
-  const tokens = req.body.Body.toUpperCase().split(" ");
+  const tokens = req.body.Body.trim().replace(/\s+/g, ' ').toUpperCase().split(" ");
   const numTokens = tokens.length;
 
   if (numTokens > 2) {


### PR DESCRIPTION
Resolved 'too many commands' bug regarding white space around incoming texts. The solution was to replace all white space with a single space, and then trim the white space around the edges of each input string. texts.